### PR TITLE
Fix of QD files parsing

### DIFF
--- a/Stoner/formats/instruments.py
+++ b/Stoner/formats/instruments.py
@@ -222,15 +222,15 @@ class QDFile(Core.DataFile):
 
             if python_v3:
                 column_headers = f.readline().strip().split(",")
-                if "," not in f.readline():
-                    raise Core.StonerLoadError("No data in file!")
             else:
                 column_headers = f.next().strip().split(",")
-                if "," not in f.next():
-                    raise Core.StonerLoadError("No data in file!")
             data = np.genfromtxt([str2bytes(l) for l in f], dtype="float", delimiter=",", invalid_raise=False)
-            if data.shape[1] != len(column_headers):  # Trap for buggy QD software not giving ewnough columns of data
+            if data.shape[0] == 0:
+                raise Core.StonerLoadError("No data in file!")
+            if data.shape[1] < len(column_headers):  # Trap for buggy QD software not giving ewnough columns of data
                 data = np.append(data, np.ones((data.shape[0], len(column_headers) - data.shape[1])) * np.NaN, axis=1)
+            elif data.shape[1] > len(column_headers):  # too much data
+                data = data[:,:len(column_headers) - data.shape[1]]
             self.data = data
         self.column_headers = column_headers
         s = self.setas


### PR DESCRIPTION
- Calling f.readline() cause that first line of the data is skipped. It is enough to check length of the data in the next step.
- Buggy QDSoftware can give also more columns of data than headers. In that case - remove last columns.